### PR TITLE
Print lines that occurred not wrapped errors

### DIFF
--- a/cmd/wraperr/main.go
+++ b/cmd/wraperr/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
-	"github.com/srvc/wraperr"
 	"github.com/pkg/errors"
+	"github.com/srvc/wraperr"
 )
 
 func main() {
@@ -20,12 +22,7 @@ func main() {
 func run() error {
 	flag.Parse()
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	err = wraperr.NewDetector().CheckPackages(flag.Args())
+	err := wraperr.NewDetector().CheckPackages(flag.Args())
 	if err == nil {
 		return nil
 	}
@@ -35,13 +32,43 @@ func run() error {
 		return errors.WithStack(err)
 	}
 
-	for _, e := range errs.Errors() {
-		pos, err := filepath.Rel(wd, e.Position.String())
-		if err != nil {
-			pos = e.Position.String()
-		}
-		fmt.Printf("%s:\t%s.%s\n", pos, e.Pkgname, e.Funcname)
-	}
+	fprintUnwrappedErrors(os.Stdout, errs)
 
 	return nil
+}
+
+func fprintUnwrappedErrors(w io.Writer, errs wraperr.UnwrappedErrors) {
+	wd, _ := os.Getwd()
+
+	for _, e := range errs.Errors() {
+		var occPos, retPos string
+		if wd != "" {
+			occPos, _ = filepath.Rel(wd, e.OccurredAt.String())
+			retPos, _ = filepath.Rel(wd, e.ReturnedAt.String())
+		}
+		if occPos == "" {
+			occPos = e.OccurredAt.String()
+		}
+		if retPos == "" {
+			retPos = e.ReturnedAt.String()
+		}
+		fmt.Fprintf(w, "%s:\t%s:\t%s\n", retPos, occPos, sprintInlineCode(e.Line))
+	}
+}
+
+func sprintInlineCode(s string) string {
+	cc := 1
+	c := cc
+	for _, r := range s {
+		if r == '`' {
+			cc++
+			if cc > c {
+				c = cc
+			}
+		} else {
+			cc = 1
+		}
+	}
+	q := strings.Repeat("`", c)
+	return q + s + q
 }

--- a/cmd/wraperr/main_test.go
+++ b/cmd/wraperr/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/srvc/wraperr"
+)
+
+func TestPrintUnwrappedErrors(t *testing.T) {
+	w := new(bytes.Buffer)
+	errs := &dummyUnwrappedErrors{
+		errs: []*wraperr.UnwrappedError{
+			{
+				Line:       "err := foo()",
+				ReturnedAt: token.Position{Filename: "foo.go", Line: 12, Column: 4},
+				OccurredAt: token.Position{Filename: "foo.go", Line: 10, Column: 8},
+			},
+			{
+				Line:       "_, err := bar()",
+				ReturnedAt: token.Position{Filename: "bar.go", Line: 19, Column: 8},
+				OccurredAt: token.Position{Filename: "baz.go", Line: 13, Column: 6},
+			},
+			{
+				Line:       "err := qux(`quux`)",
+				ReturnedAt: token.Position{Filename: "qux.go", Line: 25, Column: 12},
+				OccurredAt: token.Position{Filename: "qux.go", Line: 21, Column: 10},
+			},
+		},
+	}
+
+	fprintUnwrappedErrors(w, errs)
+
+	wantLines := []string{
+		"foo.go:12:4:	foo.go:10:8:	`err := foo()`",
+		"bar.go:19:8:	baz.go:13:6:	`_, err := bar()`",
+		"qux.go:25:12:	qux.go:21:10:	``err := qux(`quux`)``",
+	}
+
+	if got, want := w.String(), strings.Join(wantLines, "\n")+"\n"; got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+type dummyUnwrappedErrors struct {
+	wraperr.UnwrappedErrors
+	errs []*wraperr.UnwrappedError
+}
+
+func (e *dummyUnwrappedErrors) Errors() []*wraperr.UnwrappedError {
+	return e.errs
+}

--- a/detector_test.go
+++ b/detector_test.go
@@ -20,44 +20,60 @@ func TestDetector_CheckPackages(t *testing.T) {
 	}
 
 	cases := []struct {
-		test     string
-		line     int
-		funcname string
+		test       string
+		returnedOn int
+		occurredOn int
+		funcname   string
+		line       string
 	}{
 		{
-			test:     "return an error directly",
-			line:     28,
-			funcname: "returnError2",
+			test:       "return an error directly",
+			occurredOn: 28,
+			returnedOn: 28,
+			funcname:   "returnError2",
+			line:       "return returnError()",
 		},
 		{
-			test:     "return an error variable",
-			line:     39,
-			funcname: "returnError4",
+			test:       "return an error variable",
+			occurredOn: 38,
+			returnedOn: 39,
+			funcname:   "returnError4",
+			line:       "err := returnError()",
 		},
 		{
-			test:     "return an error variable in if-statement",
-			line:     52,
-			funcname: "returnError6",
+			test:       "return an error variable in if-statement",
+			occurredOn: 50,
+			returnedOn: 52,
+			funcname:   "returnError6",
+			line:       "err := returnError()",
 		},
 		{
-			test:     "return an error as named return value",
-			line:     69,
-			funcname: "returnError8",
+			test:       "return an error as named return value",
+			occurredOn: 68,
+			returnedOn: 69,
+			funcname:   "returnError8",
+			line:       "err = returnError()",
 		},
 		{
-			test:     "return a value and an error directly",
-			line:     92,
-			funcname: "returnValueAndError2",
+			test:       "return a value and an error directly",
+			occurredOn: 92,
+			returnedOn: 92,
+			funcname:   "returnValueAndError2",
+			line:       "return returnValueAndError()",
 		},
 		{
-			test:     "return a value and an error variables",
-			line:     99,
-			funcname: "returnValueAndError3",
+			test:       "return a value and an error variables",
+			occurredOn: 97,
+			returnedOn: 99,
+			funcname:   "returnValueAndError3",
+			line:       "v, err := returnValueAndError()",
 		},
 		{
-			test:     "return a value and an error as named return values",
-			line:     116,
-			funcname: "returnValueAndError5",
+			test:       "return a value and an error as named return values",
+			occurredOn: 115,
+			returnedOn: 116,
+			funcname:   "returnValueAndError5",
+			line:       "v, err = returnValueAndError()",
 		},
 	}
 
@@ -71,8 +87,16 @@ func TestDetector_CheckPackages(t *testing.T) {
 					t.Errorf("reported funcname is %s, want %s", got, want)
 				}
 
-				if got, want := unwrappedErr.Position.Line, tc.line; got != want {
-					t.Errorf("reported line# is %d, want %d", got, want)
+				if got, want := unwrappedErr.Line, tc.line; got != want {
+					t.Errorf("reported error is occurred on %q, want %q", got, want)
+				}
+
+				if got, want := unwrappedErr.OccurredAt.Line, tc.occurredOn; got != want {
+					t.Errorf("reported error is occurred on #%d, want #%d", got, want)
+				}
+
+				if got, want := unwrappedErr.ReturnedAt.Line, tc.returnedOn; got != want {
+					t.Errorf("reported error is returned on #%d, want #%d", got, want)
 				}
 			})
 		}

--- a/errors.go
+++ b/errors.go
@@ -7,9 +7,12 @@ import (
 )
 
 type UnwrappedError struct {
-	Position token.Position
-	Pkgname  string
-	Funcname string
+	Position   token.Position
+	Pkgname    string
+	Funcname   string
+	Line       string
+	ReturnedAt token.Position
+	OccurredAt token.Position
 }
 
 func (ei *UnwrappedError) less(ej *UnwrappedError) bool {

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,6 @@ import (
 )
 
 type UnwrappedError struct {
-	Position   token.Position
 	Pkgname    string
 	Funcname   string
 	Line       string
@@ -16,7 +15,7 @@ type UnwrappedError struct {
 }
 
 func (ei *UnwrappedError) less(ej *UnwrappedError) bool {
-	pi, pj := ei.Position, ej.Position
+	pi, pj := ei.ReturnedAt, ej.ReturnedAt
 
 	if pi.Filename != pj.Filename {
 		return pi.Filename < pj.Filename


### PR DESCRIPTION
## WHY

Current output (`<file>:<line>:<col>:\t<pkg>.<func>`) is meaningless...
We want to know where not wrapped errors have occurred.